### PR TITLE
Optimize SpeedTestClass::update()

### DIFF
--- a/SpeedTest.cpp
+++ b/SpeedTest.cpp
@@ -6,13 +6,13 @@ SpeedTestClass::SpeedTestClass(){};
 
 void SpeedTestClass::begin(const unsigned long loopsInput) {
   loops = loopsInput;
-  loopCount = 0;
+  loopsRemaining = loops;
   startTimestamp = millis();
 }
 
 
 boolean SpeedTestClass::update() {
-  if (++loopCount >= loops) {
+  if (--loopsRemaining == 0) {
     endTimestamp = millis();
     return true;
   }
@@ -21,7 +21,7 @@ boolean SpeedTestClass::update() {
 
 
 float SpeedTestClass::result() {
-  return (float)(endTimestamp - startTimestamp) * 1000 / loopCount;
+  return (float)(endTimestamp - startTimestamp) * 1000 / loops;
 }
 
 

--- a/SpeedTest.h
+++ b/SpeedTest.h
@@ -12,7 +12,7 @@ public:
 
 private:
   unsigned long loops;
-  unsigned long loopCount;
+  unsigned long loopsRemaining;
   unsigned long startTimestamp;
   unsigned long endTimestamp;
 };


### PR DESCRIPTION
The provided example, running on an Uno, reports a loop period around 2.51&nbsp;µs. This is 40&nbsp;CPU cycles plus a tiny overhead due to timer interrupts. By looking at the disassembly, this period can be broken down into:

- 35 cycles of measurement overhead, which are spent executing the first line of `SpeedTestClass::update()` (namely: `if (++loopCount >= loops) {`):
  - 20 cycles for loading, incrementing, and storing back `loopCount`
  - 12 cycles for loading `loops` and doing the comparison [\*]
  -  3 cycles for skipping over the following instructions
- 5 cycles to restart the whole loop

This pull request reduces the overhead of the measurement from 35 to 26&nbsp;cycles. This is done by counting down and comparing the counter to zero, instead of counting up and comparing it to `loops`. The step marked [\*] is then replaced by a three-cycle comparison.